### PR TITLE
bugfix_french_converter

### DIFF
--- a/src/main/java/pl/allegro/finance/tradukisto/internal/languages/french/FrenchIntegerToWordsConverter.java
+++ b/src/main/java/pl/allegro/finance/tradukisto/internal/languages/french/FrenchIntegerToWordsConverter.java
@@ -12,7 +12,9 @@ import static java.lang.String.format;
 
 public class FrenchIntegerToWordsConverter extends IntegerToWordsConverter {
 
-    private final Map<Integer, String> exceptions;
+    private final Map<Integer, String> exceptions; 
+    
+    private boolean baseNumbers = false;
 
     public FrenchIntegerToWordsConverter(
             IntegerToStringConverter integerToStringConverter,
@@ -26,11 +28,14 @@ public class FrenchIntegerToWordsConverter extends IntegerToWordsConverter {
 
     @Override
     public String asWords(Integer value) {
-        if (exceptions.containsKey(value)) {
+        if (exceptions.containsKey(value) && !baseNumbers) {
             return exceptions.get(value);
         }
         if (Range.closed(1000, 999999).contains(value)) {
             return thousandsAsString(value);
+        }
+        if (Range.closed(1000000, 999999999).contains(value)) {
+            return millionsAsString(value);
         }
         return super.asWords(value);
     }
@@ -48,6 +53,7 @@ public class FrenchIntegerToWordsConverter extends IntegerToWordsConverter {
 
     private String getThousandsAsWords(Integer thousands, Integer other) {
         if (nothingComesAfter(other)) {
+        	baseNumbers = true;
             return format("%s mille", asWords(thousands));
         }
         return format("%s mille %s", asWords(thousands), asWords(other));
@@ -56,12 +62,39 @@ public class FrenchIntegerToWordsConverter extends IntegerToWordsConverter {
     private String getOneThousandAsWords(Integer other) {
         return format("mille %s", asWords(other));
     }
-
+    
     private boolean nothingComesAfter(Integer other) {
         return other == 0;
     }
 
     private boolean isOneThousand(Integer thousands) {
         return thousands == 1;
+    }
+    
+    private String millionsAsString(Integer value) {
+        Integer millions = value / 1000000;
+        Integer other = value % 1000000;
+
+        if (isOneMillion(millions)) {
+            return getOneMillionAsWords(millions);
+        }
+
+        return getMillionsAsWords(millions, other);
+    }
+    
+    private String getMillionsAsWords(Integer millions, Integer other) {
+        if (nothingComesAfter(other)) {
+        	baseNumbers = true;
+            return format("%s millions", asWords(millions));
+        }
+        return format("%s millions %s", asWords(millions), asWords(other));
+    }
+    
+    private boolean isOneMillion(Integer millions) {
+        return millions == 1;
+    }
+    
+    private String getOneMillionAsWords(Integer millions) {
+        return format("%s million", asWords(millions));
     }
 }

--- a/src/test/groovy/pl/allegro/finance/tradukisto/internal/languages/french/FrenchValuesTest.groovy
+++ b/src/test/groovy/pl/allegro/finance/tradukisto/internal/languages/french/FrenchValuesTest.groovy
@@ -94,7 +94,7 @@ class FrenchValuesTest extends Specification {
         24_190        | "vingt-quatre mille cent quatre-vingt-dix"
         653_000       | "six cent cinquante-trois mille"
         123_454       | "cent vingt-trois mille quatre cent cinquante-quatre"
-        700_000       | "sept cents mille"
+        700_000       | "sept cent mille"
         999_999       | "neuf cent quatre-vingt-dix-neuf mille neuf cent quatre-vingt-dix-neuf"
 
         1_000_000     | "un million"
@@ -107,6 +107,6 @@ class FrenchValuesTest extends Specification {
 
         1_000_000_000 | "un milliard"
         2_147_483_647 | "deux milliards cent quarante-sept millions quatre cent quatre-vingt-trois mille six cent " +
-                "quarante-sept"
+                "quarante-sept" 
     }
 }


### PR DESCRIPTION
bugfix for french convertion:
deux cents euros
deux cent mille euros, cent ne prends pas de "s"
Added convertion process for Millions.