### PR TITLE
Fix CVE-2018-10237 - change guava version to 25.0-jre

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ compileJava {
 }
 
 dependencies {
-    implementation "com.google.guava:guava:23.0"
+    implementation "com.google.guava:guava:25.0-jre"
     testImplementation "org.spockframework:spock-core:1.1-groovy-2.4"
 }
 


### PR DESCRIPTION
This change fixes CVE-2018-10237 by changing guava version to 25.0-jre.