### PR TITLE
fix: CVE-2020-8908 - change guava version to 31.1-jre

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ compileJava {
 }
 
 dependencies {
-    implementation "com.google.guava:guava:25.0-jre"
+    implementation "com.google.guava:guava:31.1-jre"
     testImplementation "org.spockframework:spock-core:1.1-groovy-2.4"
 }
 


### PR DESCRIPTION
This change fixes [CVE-2020-8908](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-8908) by changing Guava version to 31.1-jre.