### PR TITLE
bugfix | change name of publication task in build.gradle.kts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   release:
     types: [ created ]
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -128,6 +128,6 @@ if (System.getenv("GPG_KEY_ID") != null) {
             System.getenv("GPG_PRIVATE_KEY"),
             System.getenv("GPG_PRIVATE_KEY_PASSWORD")
         )
-        sign(tasks["publishing.publications"])
+        sign(publishing.publications["sonatype"])
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,13 +113,12 @@ publishing {
 
 nexusPublishing {
     this.repositories {
-        register("sonatype") {
+        sonatype {
             username.set(System.getenv("SONATYPE_USERNAME"))
             password.set(System.getenv("SONATYPE_PASSWORD"))
         }
     }
 }
-
 
 if (System.getenv("GPG_KEY_ID") != null) {
     signing {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -128,6 +128,6 @@ if (System.getenv("GPG_KEY_ID") != null) {
             System.getenv("GPG_PRIVATE_KEY"),
             System.getenv("GPG_PRIVATE_KEY_PASSWORD")
         )
-        sign(publishing.publications["sonatype"])
+        sign(publishing.publications)
     }
 }


### PR DESCRIPTION
## Why?
After update to Kotlin DSL artifacts of last two versions were not published to maven central. 
```
Run ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
Downloading https://services.gradle.org/distributions/gradle-8.1.1-bin.zip
...........10%............20%............30%............40%............50%............60%............70%............80%...........90%............100%

Welcome to Gradle 8.1.1!

Here are the highlights of this release:
 - Stable configuration cache
 - Experimental Kotlin DSL assignment syntax
 - Building with Java 20

For more details see https://docs.gradle.org/8.1.1/release-notes.html

Starting a Gradle Daemon (subsequent builds will be faster)

SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
> Configure project :
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.

FAILURE: Build failed with an exception.

* Where:
Build file '/home/runner/work/tradukisto/tradukisto/build.gradle.kts' line: [13](https://github.com/allegro/tradukisto/actions/runs/6088432033/job/16535361070#step:4:14)1

* What went wrong:
Task with name 'publishing.publications' not found in root project 'tradukisto'.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org/

BUILD FAILED in 49s
Error: Process completed with exit code 1.

```
https://github.com/allegro/tradukisto/actions/runs/6088432033